### PR TITLE
Добавление в игнор папки Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-*.bik
+Build


### PR DESCRIPTION
Основная проблема предыдущей версии файла `.gitignore` в том, что при компиляции вся папка `Build` попадает под учёт гитом, что не есть хорошо. PR исправляет эту проблему.